### PR TITLE
FIX: Verifica duplicidade nos métodos alterar e cadastrar produtos e …

### DIFF
--- a/src/main/java/com/winningwomen/supermercadoYara/controller/ProdutoController.java
+++ b/src/main/java/com/winningwomen/supermercadoYara/controller/ProdutoController.java
@@ -38,7 +38,7 @@ public class ProdutoController {
 	}
 
 	@PutMapping(value = "/{id}", consumes = {"multipart/form-data"})
-	public ProdutoResponse alterarProduto(@RequestHeader HttpHeaders headers,@PathVariable Long id, @ModelAttribute @Valid ProdutoRequest produtoRequest) throws CategoriaNaoExisteException, ProdutoNaoExisteException, UsuarioNaoEAdministradorException, UsuarioNaoLogadoException {
+	public ProdutoResponse alterarProduto(@RequestHeader HttpHeaders headers,@PathVariable Long id, @ModelAttribute @Valid ProdutoRequest produtoRequest) throws CategoriaNaoExisteException, ProdutoNaoExisteException, UsuarioNaoEAdministradorException, UsuarioNaoLogadoException, AmbiguidadeDeNomesProdutosException {
 		return produtoService.alterar(headers, id, produtoRequest);
 	}
 

--- a/src/main/java/com/winningwomen/supermercadoYara/controller/UsuarioController.java
+++ b/src/main/java/com/winningwomen/supermercadoYara/controller/UsuarioController.java
@@ -26,7 +26,7 @@ public class UsuarioController {
 
 	@PostMapping
 	@ResponseStatus(HttpStatus.CREATED)
-	public void cadastrarUsuario(@RequestHeader HttpHeaders headers, @RequestBody @Valid UsuarioRequest usuarioRequest) throws AmbiguidadeDeNomesUsuariosException, FuncaoNaoExisteException, UsuarioNaoEAdministradorException, UsuarioNaoLogadoException {
+	public void cadastrarUsuario(@RequestHeader HttpHeaders headers, @RequestBody @Valid UsuarioRequest usuarioRequest) throws AmbiguidadeDeNomesUsuariosException, FuncaoNaoExisteException, UsuarioNaoEAdministradorException, UsuarioNaoLogadoException, AmbiguidadeDeEmailsException {
 		usuarioService.cadastrarUsuario(headers,usuarioRequest);
 	}
 
@@ -36,7 +36,7 @@ public class UsuarioController {
 	}
 
 	@PutMapping("/{id}")
-	public UsuarioResponse alterarUsuario(@RequestHeader HttpHeaders headers, @PathVariable Long id, @RequestBody @Valid UsuarioRequest usuarioRequest) throws AmbiguidadeDeNomesUsuariosException, UsuarioNaoExisteException, FuncaoNaoExisteException, UsuarioNaoEAdministradorException, UsuarioNaoLogadoException {
+	public UsuarioResponse alterarUsuario(@RequestHeader HttpHeaders headers, @PathVariable Long id, @RequestBody @Valid UsuarioRequest usuarioRequest) throws AmbiguidadeDeNomesUsuariosException, UsuarioNaoExisteException, FuncaoNaoExisteException, UsuarioNaoEAdministradorException, UsuarioNaoLogadoException, AmbiguidadeDeEmailsException {
 		return usuarioService.atualizar(headers, id, usuarioRequest);
 	}
 

--- a/src/main/java/com/winningwomen/supermercadoYara/dto/request/UsuarioRequest.java
+++ b/src/main/java/com/winningwomen/supermercadoYara/dto/request/UsuarioRequest.java
@@ -11,7 +11,7 @@ public class UsuarioRequest {
 
     @NotNull(message = "Campo username não pode ser nulo.")
     @NotEmpty(message = "Campo username não pode ser vazio.")
-    private String user_name;
+    private String userName;
     @NotNull(message = "Campo nome não pode ser nulo.")
     @NotEmpty(message = "Campo nome não pode ser vazio.")
     private String nome;

--- a/src/main/java/com/winningwomen/supermercadoYara/dto/response/UsuarioResponse.java
+++ b/src/main/java/com/winningwomen/supermercadoYara/dto/response/UsuarioResponse.java
@@ -14,13 +14,13 @@ import java.time.LocalDateTime;
 @Builder
 public class UsuarioResponse {
 
-    private String user_name;
+    private String userName;
     private String nome;
     private String sobrenome;
     private String email;
     private String senha;
     @JsonFormat(pattern = "dd-MM-yyyy hh:mm:ss")
-    private LocalDateTime data_criacao;
+    private LocalDateTime dataCriacao;
 	private String nomeFuncao;
 	
     public UsuarioResponse(Usuario usuarioCompleto) {

--- a/src/main/java/com/winningwomen/supermercadoYara/exception/AmbiguidadeDeEmailsException.java
+++ b/src/main/java/com/winningwomen/supermercadoYara/exception/AmbiguidadeDeEmailsException.java
@@ -1,0 +1,14 @@
+package com.winningwomen.supermercadoYara.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class AmbiguidadeDeEmailsException extends Exception {
+    public AmbiguidadeDeEmailsException (String email) {
+        super("Já existe um usuario cadastrado com o email: " + email);
+    }
+}

--- a/src/main/java/com/winningwomen/supermercadoYara/exception/AmbiguidadeDeNomesUsuariosException.java
+++ b/src/main/java/com/winningwomen/supermercadoYara/exception/AmbiguidadeDeNomesUsuariosException.java
@@ -10,7 +10,7 @@ public class AmbiguidadeDeNomesUsuariosException extends Exception {
 	 */
 	private static final long serialVersionUID = 1L;
 
-	public AmbiguidadeDeNomesUsuariosException(String user_name){
-        super("Já existe um usuario cadastrado com o nome '"+user_name+"'.");
+	public AmbiguidadeDeNomesUsuariosException(String userName){
+        super("Já existe um usuario cadastrado com o username '"+userName+"'.");
     }
 }

--- a/src/main/java/com/winningwomen/supermercadoYara/model/Categoria.java
+++ b/src/main/java/com/winningwomen/supermercadoYara/model/Categoria.java
@@ -8,6 +8,7 @@ import javax.persistence.Table;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.winningwomen.supermercadoYara.dto.request.CategoriaRequest;
 
 import lombok.*;
@@ -27,6 +28,7 @@ public class Categoria {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@JsonIgnore
 	private Long id;
 
 	@NotNull(message = "Campo username não pode ser nulo.")

--- a/src/main/java/com/winningwomen/supermercadoYara/model/Funcao.java
+++ b/src/main/java/com/winningwomen/supermercadoYara/model/Funcao.java
@@ -8,6 +8,7 @@ import javax.persistence.Table;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.winningwomen.supermercadoYara.dto.request.FuncaoRequest;
 
 import lombok.*;
@@ -28,6 +29,7 @@ public class Funcao {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@JsonIgnore
 	private Long id;
 
 	@NotNull(message = "Campo username não pode ser nulo.")

--- a/src/main/java/com/winningwomen/supermercadoYara/model/Usuario.java
+++ b/src/main/java/com/winningwomen/supermercadoYara/model/Usuario.java
@@ -20,7 +20,7 @@ import java.time.LocalDateTime;
 public class Usuario {
 	
 	public Usuario(UsuarioRequest usuarioRequest, Funcao funcao) {
-		this.setUser_name(usuarioRequest.getUser_name());
+		this.setUserName(usuarioRequest.getUserName());
 		this.setNome(usuarioRequest.getNome());
 		this.setSobrenome(usuarioRequest.getSobrenome());
 		this.setEmail(usuarioRequest.getEmail());
@@ -36,7 +36,7 @@ public class Usuario {
 	@NotNull(message = "Campo username não pode ser nulo.")
 	@NotEmpty(message = "Campo username não pode ser vazio.")
     @Column(nullable = false, length = 15)
-    private String user_name;
+    private String userName;
 
     @Column(nullable = false, length = 50)
 	@NotNull(message = "Campo nome não pode ser nulo.")

--- a/src/main/java/com/winningwomen/supermercadoYara/repository/ProdutoRepository.java
+++ b/src/main/java/com/winningwomen/supermercadoYara/repository/ProdutoRepository.java
@@ -16,4 +16,5 @@ public interface ProdutoRepository extends JpaRepository<Produto, Long>{
     List<Produto> findAllByOrderByNomeAsc();
     Optional<Produto> findById(Long id);
     void deleteById(Long id);
+    Produto findByNomeIgnoringCase(String nome);
 }

--- a/src/main/java/com/winningwomen/supermercadoYara/repository/UsuarioRepository.java
+++ b/src/main/java/com/winningwomen/supermercadoYara/repository/UsuarioRepository.java
@@ -10,7 +10,10 @@ import com.winningwomen.supermercadoYara.model.Usuario;
 @Repository
 public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
 
-    boolean existsByNome(String user_name);
+    boolean existsByUserName(String user_name);
 	List<Usuario> findAllByOrderByNomeAsc();
     Usuario findByEmailEqualsAndSenhaEquals(String email, String senha);
+    Usuario findByUserName(String userName);
+    boolean existsByEmail(String email);
+    Usuario findByEmailEquals(String email);
 }

--- a/src/main/java/com/winningwomen/supermercadoYara/service/FuncaoService.java
+++ b/src/main/java/com/winningwomen/supermercadoYara/service/FuncaoService.java
@@ -31,7 +31,7 @@ public class FuncaoService {
 	}
 	
 	public void cadastrar(HttpHeaders headers, FuncaoRequest funcaoRequest) throws UsuarioNaoEAdministradorException, UsuarioNaoLogadoException {
-		//loginService.verificaSeTokenValidoESeAdministradorELancaExcecoes(headers);
+		loginService.verificaSeTokenValidoESeAdministradorELancaExcecoes(headers);
 		Funcao funcao = new Funcao(funcaoRequest);
 		funcaoRepository.save(funcao);
 	}

--- a/src/main/java/com/winningwomen/supermercadoYara/service/ProdutoService.java
+++ b/src/main/java/com/winningwomen/supermercadoYara/service/ProdutoService.java
@@ -79,12 +79,17 @@ public class ProdutoService {
 		return listaProdutosResponse;
 	}
 
-	public ProdutoResponse alterar(HttpHeaders headers, Long id, ProdutoRequest produtoRequest) throws ProdutoNaoExisteException, CategoriaNaoExisteException, UsuarioNaoEAdministradorException, UsuarioNaoLogadoException {
+	public ProdutoResponse alterar(HttpHeaders headers, Long id, ProdutoRequest produtoRequest) throws ProdutoNaoExisteException, CategoriaNaoExisteException, UsuarioNaoEAdministradorException, UsuarioNaoLogadoException, AmbiguidadeDeNomesProdutosException {
 		loginService.verificaSeTokenValidoESeAdministradorELancaExcecoes(headers);
 
 		Produto produto = buscaProduto(id);
 		Categoria categoria = categoriaService.buscarPeloId(produtoRequest.getIdCategoria());
 		String urlImagem = imagemService.salvarImagem(produtoRequest.getImagem());
+
+		if(repository.existsByNome(produtoRequest.getNome())){
+			if(!Objects.equals(repository.findByNomeIgnoringCase(produtoRequest.getNome()).getId(), id))
+				throw new AmbiguidadeDeNomesProdutosException(produtoRequest.getNome());
+		}
 
 		produto.setNome(produtoRequest.getNome());
 		produto.setCategoria(categoria);


### PR DESCRIPTION
…usuários

Não estava sendo realizada a conferência dos atributos que devem ser únicos ao realizar a atualização de produtos e usuários. Além disso, no cadastro de usuários, não era verificado se já havia o email no banco